### PR TITLE
Add --network support when replaying Kubernetes YAML files.

### DIFF
--- a/pods-compose.ini
+++ b/pods-compose.ini
@@ -2,6 +2,7 @@
 kubedir = /var/lib/pods-compose/kube
 basedir = /path/to/parent/of/build/contexts
 default_tag = prod
+networks  = podman
 
 [builds]
 #image_php = example/php74-fpm-debian:%(default_tag)s,%(basedir)s/containerfiles/php74-fpm/php-upstream-debian

--- a/pods-compose.py
+++ b/pods-compose.py
@@ -143,9 +143,13 @@ if __name__ == "__main__":
 
         def _up_kube(kube):
             kubeyml = kubedir / kube
+            networks = config['DEFAULT']['networks']
+            netcmd = str()
+            if networks:
+                netcmd = " --network " + networks
             if kubeyml.exists():
                 rc = runcmd("Replay Kubernetes YAML for pod '" + kube +
-                            "'", "/usr/bin/podman play kube " + str(kubeyml), "yes")
+                            "'", "/usr/bin/podman play kube " + str(kubeyml) + netcmd, "yes")
             return rc
 
         # podman play kube only accepts a single yaml file, so we have to iterate


### PR DESCRIPTION
The default networks can be set in .ini file as a comma separated string.