### PR TITLE
Allow different locations for .ini file

### DIFF
--- a/pods-compose.py
+++ b/pods-compose.py
@@ -8,11 +8,24 @@ from subprocess import Popen, PIPE
 import sys
 import argparse
 import os
+import os.path
 import configparser
+from pathlib import Path
+
+INIFILE = 'pods-compose.ini'
+DOTFILE = '.'+ INIFILE
+HOME = os.path.expandvars("$HOME")
+ETC = "/etc/pods-compose"
+SCRIPT_LOC = os.path.dirname(os.path.abspath(__file__))
+for location in HOME, ETC, SCRIPT_LOC:
+    CONFIGFILE = os.path.join(location, INIFILE)
+    if os.path.exists(CONFIGFILE): break
+    if location == HOME:
+        CONFIGFILE = os.path.join(location, DOTFILE)
+        if os.path.exists(CONFIGFILE): break
 
 config = configparser.ConfigParser()
-script_location = os.path.dirname(os.path.abspath(__file__))
-config.read(script_location+'/pods-compose.ini')
+config.read(CONFIGFILE)
 
 if __name__ == "__main__":
 

--- a/pods-compose.py
+++ b/pods-compose.py
@@ -10,7 +10,6 @@ import argparse
 import os
 import os.path
 import configparser
-from pathlib import Path
 
 INIFILE = 'pods-compose.ini'
 DOTFILE = '.'+ INIFILE


### PR DESCRIPTION
This patch allows the .ini file to be located in a number of locations. The first location where it is found is used.

The locations searched are:

~/pods-compose.ini
~/.pods-compose.ini
/etc/pods-compose/pods-compose.ini
<script_dir>/pods-compose.ini (the original code)